### PR TITLE
refactor(hooks): drop onlyOwner from view-only hook helpers

### DIFF
--- a/src/hooks/ERC4626ApproveAndDepositHook.sol
+++ b/src/hooks/ERC4626ApproveAndDepositHook.sol
@@ -117,7 +117,6 @@ contract ERC4626ApproveAndDepositHook is IHook, IHookResult, Ownable {
         external
         view
         override
-        onlyOwner
         returns (Execution[] memory _executions)
     {
         ApproveAndDepositData memory _depositData = abi.decode(_data, (ApproveAndDepositData));
@@ -364,7 +363,7 @@ contract ERC4626ApproveAndDepositHook is IHook, IHookResult, Ownable {
     /// @notice Validates that the deposit produced at least the minimum expected shares
     /// @dev This function is called as part of the execution chain for slippage protection
     /// @param _minShares The minimum expected shares
-    function validateMinShares(uint256 _minShares) external view onlyOwner {
+    function validateMinShares(uint256 _minShares) external view {
         require(_depositContext.sharesReceived >= _minShares, HOOK4626DEPOSIT_INSUFFICIENT_SHARES);
     }
 

--- a/src/hooks/ERC4626RedeemHook.sol
+++ b/src/hooks/ERC4626RedeemHook.sol
@@ -105,7 +105,6 @@ contract ERC4626RedeemHook is IHook, IHookResult, Ownable {
         external
         view
         override
-        onlyOwner
         returns (Execution[] memory _executions)
     {
         RedeemData memory _redeemData = abi.decode(_data, (RedeemData));
@@ -320,7 +319,7 @@ contract ERC4626RedeemHook is IHook, IHookResult, Ownable {
     /// @notice Validates that the redemption produced at least the minimum expected assets
     /// @dev This function is called as part of the execution chain for slippage protection
     /// @param _minAssets The minimum expected assets
-    function validateMinAssets(uint256 _minAssets) external view onlyOwner {
+    function validateMinAssets(uint256 _minAssets) external view {
         require(_redeemContext.assetsReceived >= _minAssets, HOOK4626REDEEM_INSUFFICIENT_ASSETS);
     }
 

--- a/src/hooks/OneInchSwapHook.sol
+++ b/src/hooks/OneInchSwapHook.sol
@@ -171,7 +171,6 @@ contract OneInchSwapHook is IHook, IHookResult, Ownable, ReentrancyGuard {
         external
         view
         override
-        onlyOwner
         returns (Execution[] memory _executions)
     {
         SwapData memory _swapData = abi.decode(_data, (SwapData));
@@ -505,7 +504,7 @@ contract OneInchSwapHook is IHook, IHookResult, Ownable, ReentrancyGuard {
 
     /// @notice Validates that the swap produced at least the minimum expected output
     /// @param _minAmountOut The minimum expected output amount
-    function validateMinOutput(uint256 _minAmountOut) external view onlyOwner onlyInsideChain {
+    function validateMinOutput(uint256 _minAmountOut) external view onlyInsideChain {
         require(_swapContext.amountOut >= _minAmountOut, HOOKONEINCH_INSUFFICIENT_OUTPUT);
     }
 


### PR DESCRIPTION
Per Phase 4 audit Appendix C item 16: `onlyOwner` on view functions of the metawallet hooks added a ~2400-gas modifier check on every call without contributing to the security model — the data exposed by these view functions (the deterministic Execution[] array, the boolean min* validations against context state) is already inferable on-chain through traces and storage reads.

Removed `onlyOwner` from:
  - ERC4626RedeemHook.buildExecutions  / validateMinAssets
  - ERC4626ApproveAndDepositHook.buildExecutions / validateMinShares
  - OneInchSwapHook.buildExecutions / validateMinOutput (kept `onlyInsideChain` on validateMinOutput — that flag-based gate IS load-bearing for execution-context safety)

State-changing hook entry points (`resolveDynamicAmount`, `storeRedeemContextStatic`, `storeDepositContextStatic`, `storeSwapContextStatic`) keep their `onlyOwner` — those are real auth gates.

Phase 4 item 16 of 19. 137 / 137 tests pass.